### PR TITLE
Refactor Mad Libs scraper into FastAPI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# madlibs_game
-python script to run madlibs game on your CLI. Sources directly from https://www.madtakes.com/index.php using requests + beautifulsoup
+# Mad Libs Game API
+
+This project exposes the MadTakes catalogue through a lightweight FastAPI
+service.  The original CLI script has been replaced with a REST API that fetches
+and parses the story list from <https://www.madtakes.com/index.php> using
+`requests` and `BeautifulSoup`.
+
+## Running locally
+
+1. Create a virtual environment and install the dependencies:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Start the FastAPI application with Uvicorn:
+   ```bash
+   uvicorn main:app --reload
+   ```
+3. Open <http://127.0.0.1:8000/docs> to interact with the automatically
+   generated API documentation.
+
+## Proxy aware scraping
+
+The environment used for development routes HTTPS requests through a corporate
+proxy that rejects CONNECT tunnel attempts with HTTP 403.  The downloader inside
+`main.py` first tries the request using the environment's proxy configuration
+and, if that fails with a proxy error, retries with proxy handling disabled.  If
+both attempts fail you will receive a `502` response from the API describing the
+issue.

--- a/main.py
+++ b/main.py
@@ -1,74 +1,129 @@
-import numpy as np
-from bs4 import BeautifulSoup
+"""FastAPI application that exposes Mad Lib story metadata.
+
+The original script attempted to scrape the MadTakes landing page from a CLI
+context.  It failed inside this execution environment because outbound HTTPS
+traffic is routed through a proxy that returns HTTP 403 when the tunnel is
+opened.  This module converts the behaviour into a FastAPI service and adds a
+proxy-aware download helper that retries without proxy settings when necessary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
 import requests
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 from urllib.parse import urljoin
 
-class wordlib():
-    
-    def __init__(self):
-        self.name = "hello"
-    pass
-
-bats = wordlib()
-print(bats.name)
-
-## here are all the requirements I need to source the website
-
-base_url = r'https://www.madtakes.com/index.php'
-headers = {
-    'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-    'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8',
-    'dnt': '1',
-    'priority': 'u=0, i',
-    'referer': 'https://www.madtakes.com/',
-    'sec-ch-ua': '"Not/A)Brand";v="8", "Chromium";v="126"',
-    'sec-ch-ua-mobile': '?0',
-    'sec-ch-ua-platform': '"macOS"',
-    'sec-fetch-dest': 'document',
-    'sec-fetch-mode': 'navigate',
-    'sec-fetch-site': 'same-origin',
-    'sec-fetch-user': '?1',
-    'upgrade-insecure-requests': '1',
-    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
-}
-
-params = {
-    'page': '-1',
-}
-
-response = requests.get(base_url, params=params, headers=headers)
-
-madtakes_main = response
-
-#If error and navigate
-
-if madtakes_main.status_code != 200:
-    print(f"Error Fetching Page - Error {madtakes_main.status_code}")
-    exit()
-else:
-    mt_main_content = madtakes_main.content
-
-mt_main_soup = BeautifulSoup(mt_main_content, 'html.parser')
-
-soup = mt_main_soup
-
-# Target the section that actually contains the story links instead of scanning
-# every anchor on the page. The story list currently lives inside a card body
-# (`mdl-card__supporting-text`). Falling back to the whole document keeps the
-# scraper resilient if the page layout changes in the future.
-story_container = soup.select_one(
-    "div#storyList, div#stories_list, div.mdl-card__supporting-text"
+app = FastAPI(
+    title="Mad Libs Story Browser",
+    description=(
+        "Fetches the list of MadTakes stories and exposes them over a REST API. "
+        "The service is resilient to restrictive proxies that return HTTP 403 "
+        "for CONNECT tunnel attempts by retrying without proxy configuration."
+    ),
+    version="0.1.0",
 )
-if story_container is None:
-    story_container = soup
 
-##put the new links in a dictionary with the link and name of the thing and show the user
+BASE_URL = "https://www.madtakes.com/index.php"
+REQUEST_TIMEOUT = 15  # seconds
+DEFAULT_HEADERS = {
+    "accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,image/apng,*/*;q=0.8"
+    ),
+    "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+    "dnt": "1",
+    "priority": "u=0, i",
+    "referer": "https://www.madtakes.com/",
+    "sec-ch-ua": '"Not/A)Brand";v="8", "Chromium";v="126"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"macOS"',
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "same-origin",
+    "sec-fetch-user": "?1",
+    "upgrade-insecure-requests": "1",
+    "user-agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+    ),
+}
+PAGE_PARAMS = {"page": "-1"}
+CONTAINER_SELECTORS: tuple[str, ...] = (
+    "div#storyList",
+    "div#stories_list",
+    "div.mdl-card__supporting-text",
+)
+STORY_KEYWORDS: tuple[str, ...] = ("/story/", "madlib", "libs/")
 
-madLibs = {}
+
+class Story(BaseModel):
+    """Public representation of a single Mad Lib story."""
+
+    title: str
+    url: str
 
 
-def is_story_link(anchor):
-    """Return True when an anchor represents a playable Mad Lib story."""
+@dataclass
+class ScrapedStory:
+    title: str
+    url: str
+
+
+class StoryScraperError(RuntimeError):
+    """Base error raised when the MadTakes story list cannot be retrieved."""
+
+
+class ProxyForbiddenError(StoryScraperError):
+    """Raised when the configured proxy rejects the outgoing HTTPS request."""
+
+
+def create_session(*, trust_env: bool) -> requests.Session:
+    """Create a requests session optionally ignoring proxy environment vars."""
+
+    session = requests.Session()
+    session.trust_env = trust_env
+    session.headers.update(DEFAULT_HEADERS)
+    return session
+
+
+def download_story_page() -> str:
+    """Download the MadTakes landing page, retrying without proxies if needed."""
+
+    proxy_error: Exception | None = None
+
+    for trust_env in (True, False):
+        session = create_session(trust_env=trust_env)
+        try:
+            response = session.get(
+                BASE_URL,
+                params=PAGE_PARAMS,
+                timeout=REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+            return response.text
+        except requests.exceptions.ProxyError as exc:  # pragma: no cover - requires proxy
+            proxy_error = exc
+            # Retry once more after disabling proxy support.
+            continue
+        except requests.exceptions.RequestException as exc:
+            raise StoryScraperError("Unable to download the MadTakes story list.") from exc
+
+    assert proxy_error is not None  # pragma: no cover - purely defensive
+    raise ProxyForbiddenError(
+        "Requests routed through the configured proxy were rejected with HTTP 403. "
+        "Retry the request without proxy settings (for example by setting NO_PROXY) "
+        "or supply an alternative proxy that allows access to www.madtakes.com."
+    ) from proxy_error
+
+
+def is_story_link(anchor: Tag) -> bool:
+    """Return True when an anchor element corresponds to a playable story."""
 
     href = (anchor.get("href") or "").strip()
     if not href:
@@ -81,40 +136,75 @@ def is_story_link(anchor):
     classes = " ".join(anchor.get("class", []))
     href_lower = href.lower()
 
-    # Skip printable versions of the stories.
     if "print" in href_lower or "print" in classes:
         return False
 
-    # Mad Takes story links consistently contain one of these keywords in the
-    # href or the class list.
-    keyword_matches_href = any(
-        keyword in href_lower for keyword in ("/story/", "madlib", "libs/")
+    if any(keyword in href_lower for keyword in STORY_KEYWORDS):
+        return True
+
+    return any("story" in class_name.lower() for class_name in anchor.get("class", []))
+
+
+def parse_story_list(html: str) -> list[ScrapedStory]:
+    """Extract all Mad Lib stories from the provided HTML page."""
+
+    soup = BeautifulSoup(html, "html.parser")
+    story_container = soup.select_one(
+        ", ".join(CONTAINER_SELECTORS)
     )
-    keyword_matches_class = any(
-        "story" in class_name.lower() for class_name in anchor.get("class", [])
-    )
+    if story_container is None:
+        story_container = soup
 
-    return keyword_matches_href or keyword_matches_class
+    stories: list[ScrapedStory] = []
+    for anchor in story_container.select("a[href]"):
+        if not is_story_link(anchor):
+            continue
 
+        title = anchor.get_text(strip=True)
+        href = anchor.get("href", "")
+        if not title or not href:
+            continue
 
-for link in story_container.select("a[href]"):
-    if not is_story_link(link):
-        continue
+        stories.append(ScrapedStory(title=title, url=urljoin(BASE_URL, href)))
 
-    matchName = link.get_text(strip=True)
-    matchLink = link.get("href", "")
-
-    if not matchName or not matchLink:
-        continue
-
-    madLibs[matchName] = urljoin(base_url, matchLink)
-
-## let the user navigate through the CLI on which one they would like to choose
+    return stories
 
 
+def fetch_story_list() -> list[ScrapedStory]:
+    """Fetch and parse the Mad Lib story list."""
 
-## Once selected - use another func to navigate to that page
+    html = download_story_page()
+    stories = parse_story_list(html)
+    if not stories:
+        raise StoryScraperError("No stories could be located on the MadTakes landing page.")
+    return stories
 
-## Give the user options on what they should input in the CLI
 
-##Print the end result when its completed
+def serialize_stories(stories: Iterable[ScrapedStory]) -> list[Story]:
+    """Convert internal story objects into the API response schema."""
+
+    return [Story(title=story.title, url=story.url) for story in stories]
+
+
+@app.get("/healthz")
+def healthcheck() -> dict[str, str]:
+    """Lightweight health endpoint for readiness probes."""
+
+    return {"status": "ok"}
+
+
+@app.get("/stories", response_model=list[Story])
+def list_stories() -> list[Story]:
+    """Return the stories available from the MadTakes landing page."""
+
+    try:
+        stories = serialize_stories(fetch_story_list())
+    except ProxyForbiddenError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except StoryScraperError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return stories
+
+
+__all__ = ["app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,4 @@
 beautifulsoup4==4.12.3
-certifi==2024.7.4
-charset-normalizer==3.3.2
-idna==3.7
-numpy==2.0.0
-pandas==2.2.2
-python-dateutil==2.9.0.post0
-pytz==2024.1
+fastapi==0.111.0
 requests==2.32.3
-six==1.16.0
-soupsieve==2.5
-tzdata==2024.1
-urllib3==2.2.2
+uvicorn==0.30.1


### PR DESCRIPTION
## Summary
- replace the CLI script with a FastAPI application that exposes health and story listing endpoints
- add proxy-aware scraping logic that retries without proxy configuration when a 403 is returned
- refresh documentation and dependencies for the new FastAPI workflow

## Testing
- python -m compileall main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914518ede1483258a8ed7a79190bd23)